### PR TITLE
FEATURE: Disable Boundary Checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const np = require('number-precision')
 
 module.exports = () => {
+  np.enableBoundaryChecking(false);
+  
   return {
     postcssPlugin: 'postcss-aspect-ratio-polyfill',
     Declaration: {


### PR DESCRIPTION
On every render, log messages showing up from number-precision for every aspect-ratio.
This fix deactivates the BoundaryChecking on number-precision.

Example:
[1] 968619246861924900 is beyond boundary when transfer to integer, the results may not be accurate
[1] 11517412935323384 is beyond boundary when transfer to integer, the results may not be accurate
[1] 11517412935323384 is beyond boundary when transfer to integer, the results may not be accurate
[1] 1151741293532338400 is beyond boundary when transfer to integer, the results may not be accurate